### PR TITLE
Add CSV upload feature

### DIFF
--- a/FE/index.html
+++ b/FE/index.html
@@ -6,7 +6,7 @@
     <title>Signature Event Management</title>
     <style>
         body { font-family: Arial, sans-serif; }
-        #manualInput, #dashboard { display: none; margin-top: 20px; }
+        #manualInput, #dashboard, #csvData { display: none; margin-top: 20px; }
         table { border-collapse: collapse; width: 100%; }
         table, th, td { border: 1px solid #ccc; }
         th, td { padding: 8px; text-align: left; }
@@ -15,8 +15,14 @@
 <body>
     <h1>Signature Event Management</h1>
     <button id="uploadCsvBtn">Carica File CSV</button>
+    <input type="file" id="csvFileInput" accept=".csv" style="display: none;">
     <button id="manualInputBtn">Inserisci Dati Manualmente</button>
     <button id="dashboardBtn">Visualizza Dashboard</button>
+
+    <section id="csvData">
+        <h2>Dati CSV</h2>
+        <table id="csvTable"></table>
+    </section>
 
     <section id="manualInput">
         <h2>Inserimento Manuale</h2>
@@ -44,6 +50,7 @@
     </section>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/FE/script.js
+++ b/FE/script.js
@@ -1,7 +1,11 @@
 const manualInputBtn = document.getElementById('manualInputBtn');
 const dashboardBtn = document.getElementById('dashboardBtn');
+const uploadCsvBtn = document.getElementById('uploadCsvBtn');
+const csvFileInput = document.getElementById('csvFileInput');
 const manualSection = document.getElementById('manualInput');
 const dashboardSection = document.getElementById('dashboard');
+const csvSection = document.getElementById('csvData');
+const csvTable = document.getElementById('csvTable');
 
 manualInputBtn.addEventListener('click', () => {
     const isHidden = manualSection.style.display === 'none';
@@ -13,4 +17,49 @@ dashboardBtn.addEventListener('click', () => {
     const isHidden = dashboardSection.style.display === 'none';
     dashboardSection.style.display = isHidden ? 'block' : 'none';
     manualSection.style.display = 'none';
+    csvSection.style.display = 'none';
 });
+
+uploadCsvBtn.addEventListener('click', () => {
+    csvFileInput.click();
+});
+
+csvFileInput.addEventListener('change', (event) => {
+    const file = event.target.files[0];
+    if (file) {
+        Papa.parse(file, {
+            header: true,
+            skipEmptyLines: true,
+            complete: (results) => {
+                renderCsvTable(results.data);
+            }
+        });
+    }
+});
+
+function renderCsvTable(data) {
+    csvTable.innerHTML = '';
+
+    const headers = ['Mese', 'Severity 1 case', 'ProM Critical Alert', 'ProM Warning Alert', 'System Outage'];
+    const headerRow = document.createElement('tr');
+    headers.forEach(h => {
+        const th = document.createElement('th');
+        th.textContent = h;
+        headerRow.appendChild(th);
+    });
+    csvTable.appendChild(headerRow);
+
+    data.forEach(row => {
+        const tr = document.createElement('tr');
+        headers.forEach(h => {
+            const td = document.createElement('td');
+            td.textContent = row[h] || '';
+            tr.appendChild(td);
+        });
+        csvTable.appendChild(tr);
+    });
+
+    csvSection.style.display = 'block';
+    manualSection.style.display = 'none';
+    dashboardSection.style.display = 'none';
+}


### PR DESCRIPTION
## Summary
- enable CSV file input on the page
- parse CSV with PapaParse and render data to a table
- include PapaParse via CDN

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_685acbcba77883249ffac444a9f04980