### PR TITLE
Add data endpoint

### DIFF
--- a/BE/data/data.json
+++ b/BE/data/data.json
@@ -1,0 +1,3 @@
+{
+  "message": "Hello from data file!"
+}

--- a/BE/server.js
+++ b/BE/server.js
@@ -32,6 +32,26 @@ const csvFilter = (_req, file, cb) => {
 
 const upload = multer({ storage, fileFilter: csvFilter });
 
+// Endpoint to read a JSON file from the data directory
+app.get('/data', (_req, res) => {
+  const dataPath = path.join(__dirname, 'data', 'data.json');
+
+  fs.readFile(dataPath, 'utf8', (err, fileContents) => {
+    if (err) {
+      console.error('Error reading JSON file:', err);
+      return res.status(500).json({ error: 'Failed to read data' });
+    }
+
+    try {
+      const jsonData = JSON.parse(fileContents);
+      res.json(jsonData);
+    } catch (parseErr) {
+      console.error('Error parsing JSON:', parseErr);
+      res.status(500).json({ error: 'Invalid JSON format' });
+    }
+  });
+});
+
 // Endpoint to upload a CSV file
 app.post('/upload', upload.single('file'), (req, res) => {
   if (!req.file) {


### PR DESCRIPTION
## Summary
- add `/data` endpoint to read JSON file from `data` folder
- create example `data.json` file

## Testing
- `npm install`
- `node server.js &`
- `curl -s http://localhost:3000/data`

------
https://chatgpt.com/codex/tasks/task_e_685ad1220f688324a740c0b3d3dda9b8