### PR TITLE
Allow overriding server port via env

### DIFF
--- a/BE/server.js
+++ b/BE/server.js
@@ -5,7 +5,8 @@ const multer = require('multer');
 const fs = require('fs');
 
 const app = express();
-const PORT = 3000;
+// Environment variable overrides the default port
+const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- allow BE server's port to be set using the `PORT` environment variable

## Testing
- `node BE/server.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_685afbbca9388324a0dd42f6705469c1