### PR TITLE
Add Heroku Procfile and root package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 *.log
 
 # others
+node_modules/

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node BE/server.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sig-disruptive-events",
+  "version": "1.0.0",
+  "description": "",
+  "main": "BE/server.js",
+  "scripts": {
+    "start": "node BE/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "multer": "^1.4.4"
+  },
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add a Procfile pointing to the backend server
- add a root `package.json` so Heroku detects the Node buildpack
- ignore top-level `node_modules` directory

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test" as expected)*

------
https://chatgpt.com/codex/tasks/task_e_685b13cdbda883248f9840ba613ab32c