### PR TITLE
Add server setup and endpoint documentation

### DIFF
--- a/BE/readme.txt
+++ b/BE/readme.txt
@@ -1,12 +1,58 @@
 Backend API
 ===========
 
-This directory contains the Express server for the project.
-
-All responses are JSON formatted. Requests to routes that are not defined will
-return a 404 status code with the JSON body `{"error":"Not found"}`.
+This directory contains the Express server for the project. All endpoints reply with JSON.
+Requests to undefined routes return a 404 status code with `{\"error\":\"Not found\"}`.
 
 Configuration Notes
 -------------------
-The configuration file `config/config.json` now uses the key `severity1` instead
-of the old `s1` name. Update any custom scripts accordingly.
+The configuration file `config/config.json` now uses the key `severity1` instead of the
+old `s1` name. Update any custom scripts accordingly.
+
+Running the Server
+------------------
+1. Install dependencies:
+   ```
+   npm install
+   ```
+2. Start the server with:
+   ```
+   node BE/server.js
+   ```
+   or simply `npm start`. The application listens on the `PORT` environment variable
+   or defaults to **3000**.
+
+Available Endpoints
+-------------------
+### `GET /config`
+Returns the contents of `config/config.json`.
+
+### `POST /config`
+Expects a JSON body with numeric `severity1`, `critical`, `warning` and `outage` fields.
+Saves the data to `config/config.json`.
+Successful response:
+```
+{ "message": "Configuration saved successfully" }
+```
+A `400` status code is returned when the payload is invalid.
+
+### `GET /data`
+Reads `data/data.json` and returns its JSON contents.
+
+### `POST /data`
+Accepts a JSON payload and stores it in `data/data.json`.
+Successful response:
+```
+{ "message": "Data saved successfully" }
+```
+
+### `POST /upload`
+Uploads a CSV file. The request must be `multipart/form-data` with the field `file`.
+Only files with a `.csv` extension under 2 MB are accepted. Saved files appear in
+`uploads/`.
+Successful response:
+```
+{ "message": "File uploaded successfully", "filename": "<saved name>" }
+```
+
+Static files from the `FE` directory are served automatically.


### PR DESCRIPTION
## Summary
- document how to run the Express backend
- describe `/config`, `/data` and `/upload` endpoints in `BE/readme.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bbfb44f3c8324a2f305cb8f94b6a8