### PR TITLE
Add comment on csvFilter behavior

### DIFF
--- a/BE/server.js
+++ b/BE/server.js
@@ -36,6 +36,7 @@ const storage = multer.diskStorage({
   }
 });
 
+// Rejects non-CSV uploads based on MIME type or `.csv` extension
 const csvFilter = (_req, file, cb) => {
   const isCsv = file.mimetype === 'text/csv' || file.originalname.match(/\.csv$/i);
   cb(isCsv ? null : new Error('Only CSV files are allowed'), isCsv);


### PR DESCRIPTION
## Summary
- clarify that `csvFilter` rejects non-CSV uploads

## Testing
- `npm test` (fails: missing script)
- `npm test` in `BE` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_685bc0526edc8324adf50826cb3a6dd7